### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Determine repository root
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Create Python virtual environment
+if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+fi
+source .venv/bin/activate
+
+# Upgrade pip and install project in development mode with dev extras
+pip install --upgrade pip
+pip install -e ".[dev]"
+
+echo "Environment setup complete. Activate with 'source .venv/bin/activate'."


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to bootstrap a virtual environment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68423584713c8324b6d1455d3eb99232